### PR TITLE
updates aca_entities sha to the latest

### DIFF
--- a/.github/workflows/security_checks.yml
+++ b/.github/workflows/security_checks.yml
@@ -59,10 +59,10 @@ jobs:
             bundler-cache: true
         - name: install bundler-audit
           run: |
-            gem install bundler-audit && bundle-audit update
+            gem install bundler-audit && bundler-audit update
         - name: run bundler-audit
           run: |
-            bundle-audit --output=bundler_audit.txt
+            bundler-audit --output=bundler_audit.txt
         - name: upload bundler-audit failure report
           uses: actions/upload-artifact@v3
           if: failure()

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'rbtree',  '~> 0.4.5'
 gem 'sinatra', '~> 2.2.3'
 gem 'stimulus_reflex', '3.4.2'
 gem 'webpacker'
-gem 'rexml',   '~> 3.3.2'
+gem 'rexml',   '>= 3.3.3'
 gem 'actiontext', '~> 7.0.8.3'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,7 +373,7 @@ GEM
     rbtree (0.4.6)
     redis (4.5.1)
     regexp_parser (2.9.2)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rspec-core (3.10.1)
       rspec-support (~> 3.10.0)
@@ -506,7 +506,7 @@ DEPENDENCIES
   rails (~> 7.0.8.4)
   rbtree (~> 0.4.5)
   resource_registry!
-  rexml (~> 3.3.2)
+  rexml (>= 3.3.3)
   rspec-rails (~> 4.0)
   rubocop
   rubocop-git

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ideacrew/aca_entities.git
-  revision: 819f6144081fdbe8b1353947c2d024f5f76c9114
+  revision: a594cb2ab90dce26c13095e0172238e16b4d1d7c
   branch: trunk
   specs:
     aca_entities (0.10.0)

--- a/app/domain/operations/sugar_crm/transmittable/generate_request_objects.rb
+++ b/app/domain/operations/sugar_crm/transmittable/generate_request_objects.rb
@@ -11,7 +11,7 @@ module Operations
 
         def call(params)
           values = yield validate(params)
-          job_params = yield construct_job_params
+          job_params = yield construct_job_params(values)
           @job = yield create_job(job_params)
           transmission_params = yield construct_transmission_params(values)
           @transmission = yield create_request_transmission(transmission_params, @job)
@@ -36,11 +36,11 @@ module Operations
           ::Operations::Families::Create.new.call(params.merge({job: @job}))
         end
 
-        def construct_job_params
+        def construct_job_params(values)
           Success(
             {
               key: :family_created_or_updated,
-              title: "Family Created or Updated",
+              title: "Family Created or Updated for family: #{values.dig(:inbound_family_cv, :hbx_id)}.",
               description: "Job that processes a family created or updated event",
               publish_on: DateTime.now,
               started_at: DateTime.now

--- a/spec/domain/operations/sugar_crm/generate_report_spec.rb
+++ b/spec/domain/operations/sugar_crm/generate_report_spec.rb
@@ -84,4 +84,11 @@ RSpec.describe Operations::SugarCRM::GenerateReport do
       end
     end
   end
+
+  after :all do
+    # Clean up the CSV files created during the test
+    Dir.glob(Rails.root.join('crm_transmittable_report_*.csv')).each do |file|
+      FileUtils.rm(file)
+    end
+  end
 end

--- a/spec/domain/operations/sugar_crm/transmittable/generate_request_objects_spec.rb
+++ b/spec/domain/operations/sugar_crm/transmittable/generate_request_objects_spec.rb
@@ -26,6 +26,10 @@ RSpec.describe Operations::SugarCRM::Transmittable::GenerateRequestObjects, dbcl
       expect(@result.success[:job]).to be_a(Transmittable::Job)
     end
 
+    it 'creates job title by including family hbx_id' do
+      expect(@result.success[:job].title).to include(cv3_family[:hbx_id])
+    end
+
     it "generates a transmission" do
       expect(@result.success[:transmission]).to be_a(Transmittable::Transmission)
     end

--- a/spec/models/family_spec.rb
+++ b/spec/models/family_spec.rb
@@ -2,6 +2,7 @@
 
 require 'rails_helper'
 require Rails.root.join('spec/shared_contexts/transmittable_data.rb')
+require 'aca_entities/crm/libraries/crm_library'
 
 RSpec.describe Family, type: :model do
   include_context 'a full transmittable setup with family as subject'
@@ -77,6 +78,43 @@ RSpec.describe Family, type: :model do
 
       it 'returns nil' do
         expect(family.outbound_account_cv_hash).to be_nil
+      end
+    end
+  end
+
+  describe '#outbound_account_entity' do
+    context 'when outbound_payload is present' do
+      let(:date_of_birth) { (Time.zone.today - 10.years).to_s }
+
+      let(:outbound_payload) do
+        {
+          hbxid_c: '12345',
+          name: 'John Doe',
+          dob_c: date_of_birth,
+          contacts: [
+            {
+              hbxid_c: '12345',
+              first_name: 'John',
+              last_name: 'Doe',
+              birthdate: date_of_birth,
+              relationship_c: 'Self'
+            }
+          ]
+        }
+      end
+
+      let(:family) { FactoryBot.create(:family, outbound_payload: outbound_payload.to_json) }
+
+      it 'returns a account entity' do
+        expect(family.outbound_account_entity).to be_a(AcaEntities::Crm::Account)
+      end
+    end
+
+    context 'when outbound_payload is blank' do
+      let(:family) { FactoryBot.create(:family, outbound_payload: nil) }
+
+      it 'returns nil' do
+        expect(family.outbound_account_entity).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
[Pod of War - 188049393](https://www.pivotaltracker.com/story/show/188049393)

Contents of this PR:
* Updates aca_entities sha to the latest.
* Improves the title for the Job and adds necessary tests.
* Updates Git Hub Security Workflow to use `bundler-audit` throughout the scan.
* Upgrades `rexml` gem to fix the "DoS vulnerabilities in REXML" flagged by `bundler-audit`. References:
  * https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41123
  * https://www.ruby-lang.org/en/news/2024/08/01/dos-rexml-cve-2024-41946